### PR TITLE
Added null check in case widget it not on the screen anymore

### DIFF
--- a/lib/zoom_widget.dart
+++ b/lib/zoom_widget.dart
@@ -818,6 +818,10 @@ class _ZoomState extends State<Zoom>
 
   void recalculateSizes() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_parentKey.currentContext?.findRenderObject() == null) {
+        return;
+      }
+
       final RenderBox parentRenderBox =
           _parentKey.currentContext!.findRenderObject()! as RenderBox;
       parentSize = parentRenderBox.size;


### PR DESCRIPTION
Please check that my change is valid, I didn't test it and don't understand the code well enough to know what are the consequences of this change.

Probably will fix: #34 

Should I add `dispose();` before the return? because it will enter the if just when the parent no longer exists.